### PR TITLE
add indices setup_indices.py

### DIFF
--- a/db/dags/scripts/setup_indices.py
+++ b/db/dags/scripts/setup_indices.py
@@ -10,11 +10,11 @@ INDICES = [
     },
     {
         'node_label': 'Gene',
-        'property': 'uid'
+        'property': 'name'
     },
     {
         'node_label': 'Disease',
-        'property': 'uid'
+        'property': 'name'
     }
 ]
 
@@ -23,7 +23,6 @@ def create_index_query(node_type, indexed_property):
     """ Create the query for the index statement. See:
     https://neo4j.com/docs/cypher-manual/current/indexes-for-search-performance/
     """
-    print('here!!')
     print(f'CREATE INDEX ON :{node_type}({indexed_property});')
     return f'CREATE INDEX ON :{node_type}({indexed_property});'
 


### PR DESCRIPTION
Initial setup for setting up indices:
* `uid` set as index for GO node
* `uid` set as index for gene node
* `uid` set as index for disease node

Further indices can be added as needed.